### PR TITLE
feat: add public compat of template

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,3 +21,25 @@ export function clearRequireCache() {
     delete require.cache[key]
   })
 }
+
+/**
+ * /(['|"])\/?public(\/)/g
+ *   - <template> <img src='~public/img/403.png'/> </template>"
+ *   - <template><img src="~/public/img/403.svg" /></template>
+ *
+ *   - <style> #app{ background: url('~public/img/403.png') } </style>
+ *
+ * @param code : the code of Vue SFC
+ * @param id : file path
+ */
+export function templateTransform(code: string, id: string) {
+  const vueLangs = /\.(vue)$|vue&type=template|vue&type=style/
+  const publicReg = /(['|"])~?\/?public(\/)/g
+
+  // Avoid duplicate exec
+  if (vueLangs.test(id) && publicReg.test(code)) {
+    code = code.replace(publicReg, '$1$2')
+  }
+
+  return code
+}


### PR DESCRIPTION
## Background

#### `~@` Token
``` vue
// *.vue
<style lang="less">
  @import '~@/styles/colors.less';
</style>
```

``` css
@import '~@/assets/config.less';
h2 {
  color: aqua;
}
```

<br>

#### `public` Token
Need to add compat with `~public` strings

``` js
<template>
  <div>
    <img src="~/public/img/403.svg" />
  </div>

  <div>
    <img src="~public/img/403.svg" />
  </div>

  <div class="bg"></div>
</template>

<style>
.bg {
  width: 53px;
  height: 16px;
  text-align: right;
  background: url('~public/img/403.png') 0px center no-repeat;
}
</style>
```


<br>

## My Solution to the Problem
``` js
const defaultAlias = [
  {
    find: /^~@\//,
    replacement: path.join(process.cwd(), './src/'),
  },
  { find: /^~/, replacement: '' },
]
```

``` js
const vueLangs = /\.(vue)$|vue&type=template|vue&type=style/
const publicReg = /(['|"])~?\/?public(\/)/g

// Avoid duplicate exec
if (vueLangs.test(id) && publicReg.test(code)) {
  code = code.replace(publicReg, '$1$2')
}

return code
```

<br>
<br>



